### PR TITLE
feat(cubism-modern): Add automatic high precision mask option

### DIFF
--- a/src/cubism-common/InternalModel.ts
+++ b/src/cubism-common/InternalModel.ts
@@ -100,6 +100,13 @@ export interface InternalModelOptions extends MotionManagerOptions {
    * @default 0.4
    */
   lipSyncWeight?: number
+
+  /**
+   * Whether to use Cubism's high precision clipping mask rendering.
+   * Only supported by Cubism 3/4/5 models.
+   * @default 'auto'
+   */
+  useHighPrecisionMask?: boolean | 'auto'
 }
 
 const tempBounds: Bounds = { x: 0, y: 0, width: 0, height: 0 }

--- a/src/cubism-legacy/CubismLegacyInternalModel.ts
+++ b/src/cubism-legacy/CubismLegacyInternalModel.ts
@@ -79,7 +79,7 @@ export class CubismLegacyInternalModel extends InternalModel {
       { breathDepth: 1, lipSyncGain: 1.5, lipSyncWeight: 0.4 },
       options
     )
-    if (options?.useHighPrecisionMask !== undefined) {
+    if (options?.useHighPrecisionMask !== undefined && options.useHighPrecisionMask !== false) {
       logger.warn(
         'CubismLegacyInternalModel',
         '`useHighPrecisionMask` is only supported by Cubism 3/4/5 models and will be ignored for Cubism 2 models.'

--- a/src/cubism-legacy/CubismLegacyInternalModel.ts
+++ b/src/cubism-legacy/CubismLegacyInternalModel.ts
@@ -79,6 +79,12 @@ export class CubismLegacyInternalModel extends InternalModel {
       { breathDepth: 1, lipSyncGain: 1.5, lipSyncWeight: 0.4 },
       options
     )
+    if (options?.useHighPrecisionMask !== undefined) {
+      logger.warn(
+        'CubismLegacyInternalModel',
+        '`useHighPrecisionMask` is only supported by Cubism 3/4/5 models and will be ignored for Cubism 2 models.'
+      )
+    }
     this.motionManager = new CubismLegacyMotionManager(this)
     this.parallelMotionManager = []
     this.eyeBlink = new Live2DEyeBlink(coreModel)

--- a/src/cubism/CubismInternalModel.ts
+++ b/src/cubism/CubismInternalModel.ts
@@ -25,6 +25,20 @@ import { clamp } from '@/utils'
 const tempMatrix = new CubismMatrix44()
 const DEFAULT_MASKS_PER_RENDER_TEXTURE = 36
 const MASKS_PER_RENDER_TEXTURE = 32
+const HIGH_PRECISION_MASK_UNIQUE_MASK_SET_THRESHOLD = 16
+const HIGH_PRECISION_MASK_MASKED_DRAWABLE_THRESHOLD = 64
+const HIGH_PRECISION_MASK_MAX_MASKS_PER_DRAWABLE_THRESHOLD = 3
+const HIGH_PRECISION_MASK_MASKED_VERTEX_THRESHOLD = 4096
+const HIGH_PRECISION_MASK_VERTEX_RATIO_THRESHOLD = 0.5
+const HIGH_PRECISION_MASK_VERTEX_RATIO_DRAWABLE_THRESHOLD = 24
+
+type MaskProfile = {
+  maskedDrawableCount: number
+  uniqueMaskSetCount: number
+  maxMasksPerDrawable: number
+  maskedVertexCount: number
+  totalVertexCount: number
+}
 
 function getRequiredMaskRenderTextureCount(model: CubismModel): number {
   if (!model.isUsingMasking()) {
@@ -57,6 +71,78 @@ function getRequiredMaskRenderTextureCount(model: CubismModel): number {
   }
 
   return Math.ceil(clippingContextCount / MASKS_PER_RENDER_TEXTURE)
+}
+
+function getMaskProfile(model: CubismModel): MaskProfile {
+  const maskCounts = model.getDrawableMaskCounts()
+  const masks = model.getDrawableMasks()
+  const uniqueMaskSets = new Set<string>()
+  const drawableCount = model.getDrawableCount()
+
+  let maskedDrawableCount = 0
+  let maxMasksPerDrawable = 0
+  let maskedVertexCount = 0
+  let totalVertexCount = 0
+
+  for (let i = 0; i < drawableCount; i++) {
+    const vertexCount = model.getDrawableVertexCount(i)
+    const maskCount = maskCounts[i] ?? 0
+
+    totalVertexCount += vertexCount
+
+    if (maskCount <= 0) {
+      continue
+    }
+
+    maskedDrawableCount++
+    maskedVertexCount += vertexCount
+    maxMasksPerDrawable = Math.max(maxMasksPerDrawable, maskCount)
+
+    const maskSet = Array.from(masks[i] ?? [])
+      .slice(0, maskCount)
+      .sort((a, b) => a - b)
+      .join(',')
+
+    uniqueMaskSets.add(maskSet)
+  }
+
+  return {
+    maskedDrawableCount,
+    uniqueMaskSetCount: uniqueMaskSets.size,
+    maxMasksPerDrawable,
+    maskedVertexCount,
+    totalVertexCount
+  }
+}
+
+function shouldUseHighPrecisionMask(model: CubismModel): boolean {
+  if (!model.isUsingMasking()) {
+    return false
+  }
+
+  const profile = getMaskProfile(model)
+  const maskedVertexRatio =
+    profile.totalVertexCount > 0 ? profile.maskedVertexCount / profile.totalVertexCount : 0
+
+  return (
+    profile.uniqueMaskSetCount > HIGH_PRECISION_MASK_UNIQUE_MASK_SET_THRESHOLD ||
+    profile.maskedDrawableCount > HIGH_PRECISION_MASK_MASKED_DRAWABLE_THRESHOLD ||
+    profile.maxMasksPerDrawable >= HIGH_PRECISION_MASK_MAX_MASKS_PER_DRAWABLE_THRESHOLD ||
+    profile.maskedVertexCount > HIGH_PRECISION_MASK_MASKED_VERTEX_THRESHOLD ||
+    (maskedVertexRatio >= HIGH_PRECISION_MASK_VERTEX_RATIO_THRESHOLD &&
+      profile.maskedDrawableCount > HIGH_PRECISION_MASK_VERTEX_RATIO_DRAWABLE_THRESHOLD)
+  )
+}
+
+function resolveHighPrecisionMaskOption(
+  model: CubismModel,
+  option: InternalModelOptions['useHighPrecisionMask']
+): boolean {
+  if (typeof option === 'boolean') {
+    return option
+  }
+
+  return shouldUseHighPrecisionMask(model)
 }
 
 // noinspection JSUnusedGlobalSymbols
@@ -184,6 +270,9 @@ export class CubismInternalModel extends InternalModel {
     this.breath.setParameters(breathParams)
 
     this.renderer.initialize(this.coreModel, getRequiredMaskRenderTextureCount(this.coreModel))
+    this.renderer.useHighPrecisionMask(
+      resolveHighPrecisionMaskOption(this.coreModel, this.options.useHighPrecisionMask)
+    )
     this.renderer.setIsPremultipliedAlpha(true)
   }
 


### PR DESCRIPTION
From #15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 新增 `useHighPrecisionMask` 选项，可在 Cubism 3/4/5 模型上以自动或手动模式控制高精度蒙版渲染；默认支持自动判定是否启用以兼顾兼容性与性能。

* **改进**
  * 对 Cubism 2 模型若显式设置高精度蒙版选项，今会在运行时给出警告提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->