### PR TITLE
feat: add explicit Live2D plugin registration

### DIFF
--- a/README-JA.md
+++ b/README-JA.md
@@ -15,7 +15,7 @@
 
 ### PixiJS v8 ネイティブレンダリング
 
-カスタム **Render Pipe** により PixiJS v8 のレンダリングアーキテクチャに統合：
+`extensions.add(Live2DPlugin)` でカスタム **Render Pipe** を登録し、PixiJS v8 のレンダリングアーキテクチャに統合：
 
 - `Filter` および `RenderTexture` に対応
 - **zIndex ソート**・**ブレンドモード**に参加
@@ -92,7 +92,7 @@ npm install untitled-pixi-live2d-engine
 ```
 
 ```ts
-import { Live2DModel } from 'untitled-pixi-live2d-engine'
+import { Live2DModel, Live2DPlugin } from 'untitled-pixi-live2d-engine'
 
 // Cubism Legacy のみ（Cubism 2.1）
 import { Live2DModel } from 'untitled-pixi-live2d-engine/cubism-legacy'
@@ -134,8 +134,11 @@ Live2D モデルは Cubism アーキテクチャにより 2 種類に分かれ�
 以下は PixiJS v8 を使用した例で、Cubism Legacy と Cubism Modern の両方に対応します。
 
 ```ts
-import { Application } from 'pixi.js'
-import { configureCubismSDK, Live2DModel } from 'untitled-pixi-live2d-engine'
+import { Application, extensions } from 'pixi.js'
+import { configureCubismSDK, Live2DModel, Live2DPlugin } from 'untitled-pixi-live2d-engine'
+
+// Pixi renderer を作成する前に Live2D レンダリングパイプを登録
+extensions.add(Live2DPlugin)
 
 const app = new Application()
 await app.init({

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -15,7 +15,7 @@
 
 ### PixiJS v8 原生渲染
 
-通过自定义 **Render Pipe** 接入 PixiJS v8 渲染架构：
+通过 `extensions.add(Live2DPlugin)` 注册自定义 **Render Pipe**，接入 PixiJS v8 渲染架构：
 
 - 支持 `Filter`（滤镜）与 `RenderTexture`（离屏渲染）
 - 参与 **zIndex 排序** 与 **混合模式**
@@ -92,7 +92,7 @@ npm install untitled-pixi-live2d-engine
 ```
 
 ```ts
-import { Live2DModel } from 'untitled-pixi-live2d-engine'
+import { Live2DModel, Live2DPlugin } from 'untitled-pixi-live2d-engine'
 
 // 仅使用 Cubism Legacy（Cubism 2.1）
 import { Live2DModel } from 'untitled-pixi-live2d-engine/cubism-legacy'
@@ -135,8 +135,11 @@ Live2D 模型按 Cubism 架构分为两类，各自需要引入不同的外部�
 以下示例基于 PixiJS v8，同时支持 Cubism Legacy 与 Cubism Modern。
 
 ```ts
-import { Application } from 'pixi.js'
-import { configureCubismSDK, Live2DModel } from 'untitled-pixi-live2d-engine'
+import { Application, extensions } from 'pixi.js'
+import { configureCubismSDK, Live2DModel, Live2DPlugin } from 'untitled-pixi-live2d-engine'
+
+// 在创建 Pixi renderer 前注册 Live2D 渲染管线
+extensions.add(Live2DPlugin)
 
 const app = new Application()
 await app.init({

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project is a major refactor of [pixi-live2d-display-mulmotion](https://gith
 
 ### Native PixiJS v8 Rendering
 
-Integrates with the PixiJS v8 rendering architecture via a custom **Render Pipe**:
+Registers a custom **Render Pipe** with `extensions.add(Live2DPlugin)` to integrate with the PixiJS v8 rendering architecture:
 
 - Supports `Filter` and `RenderTexture`
 - Participates in **zIndex sorting** and **blend modes**
@@ -92,7 +92,7 @@ npm install untitled-pixi-live2d-engine
 ```
 
 ```ts
-import { Live2DModel } from 'untitled-pixi-live2d-engine'
+import { Live2DModel, Live2DPlugin } from 'untitled-pixi-live2d-engine'
 
 // Cubism Legacy only (Cubism 2.1)
 import { Live2DModel } from 'untitled-pixi-live2d-engine/cubism-legacy'
@@ -134,8 +134,11 @@ Download from the official [Cubism 5 SDK for Web](https://www.live2d.com/downloa
 The following example uses PixiJS v8 and supports both Cubism Legacy and Cubism Modern.
 
 ```ts
-import { Application } from 'pixi.js'
-import { configureCubismSDK, Live2DModel } from 'untitled-pixi-live2d-engine'
+import { Application, extensions } from 'pixi.js'
+import { configureCubismSDK, Live2DModel, Live2DPlugin } from 'untitled-pixi-live2d-engine'
+
+// Register the Live2D render pipe before creating the Pixi renderer
+extensions.add(Live2DPlugin)
 
 const app = new Application()
 await app.init({

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -1,5 +1,7 @@
-import { Application } from 'pixi.js'
-import { Live2DModel } from '@/Live2DModel'
+import { Application, extensions } from 'pixi.js'
+import { Live2DModel, Live2DPlugin } from '@/Live2DModel'
+
+extensions.add(Live2DPlugin)
 
 const app = new Application()
 await app.init({

--- a/src/Live2DModel.ts
+++ b/src/Live2DModel.ts
@@ -15,6 +15,7 @@ import {
   CanvasSource,
   Container,
   DOMAdapter,
+  ExtensionType,
   Matrix,
   ObservablePoint,
   Point,
@@ -71,9 +72,26 @@ type Live2DPipeRenderer = Renderer & {
   }
 }
 
-// noinspection JSUnusedGlobalSymbols
+let live2DPluginFallbackWarned = false
+
+/**
+ * Internal PixiJS render pipe for Live2D models.
+ * @internal
+ */
 class Live2DPipe {
+  static extension = {
+    type: [ExtensionType.WebGLPipes],
+    name: 'live2d'
+  } as const
+
   constructor(private renderer: Renderer) {}
+
+  addRenderable(model: Live2DModel, instructionSet: InstructionSet): void {
+    const renderPipes = (this.renderer as Live2DPipeRenderer).renderPipes
+
+    renderPipes.batch?.break?.(instructionSet)
+    instructionSet.add(model)
+  }
 
   execute(model: Live2DModel): void {
     if (!model.visible || model.alpha <= 0) {
@@ -85,13 +103,45 @@ class Live2DPipe {
 
   updateRenderable(): void {}
 
+  destroyRenderable(): void {}
+
+  validateRenderable(): boolean {
+    return false
+  }
+
   destroy(): void {}
 }
 
+/**
+ * PixiJS extension entry for registering the Live2D WebGL render pipe.
+ *
+ * Register it before creating a renderer:
+ *
+ * ```ts
+ * import { extensions } from 'pixi.js'
+ * import { Live2DPlugin } from 'untitled-pixi-live2d-engine'
+ *
+ * extensions.add(Live2DPlugin)
+ * ```
+ */
+export const Live2DPlugin = Live2DPipe
+
+/**
+ * @deprecated Register {@link Live2DPlugin} with `extensions.add(Live2DPlugin)` before
+ * creating the Pixi renderer. This lazy fallback is kept only for backward compatibility.
+ */
 function ensureLive2DPipe(renderer: Renderer): void {
   const r = renderer as Live2DPipeRenderer
 
   if (!r.renderPipes.live2d) {
+    if (!live2DPluginFallbackWarned) {
+      live2DPluginFallbackWarned = true
+      console.warn(
+        '[untitled-pixi-live2d-engine] Lazy Live2D render pipe registration is deprecated. ' +
+          'Register Live2DPlugin explicitly with `extensions.add(Live2DPlugin)` before creating the Pixi renderer.'
+      )
+    }
+
     r.renderPipes.live2d = new Live2DPipe(renderer)
   }
 }
@@ -448,8 +498,7 @@ export class Live2DModel<IM extends InternalModel = InternalModel> extends Conta
     const renderPipes = (renderer as Live2DPipeRenderer).renderPipes
 
     const addRenderable = () => {
-      renderPipes.batch?.break?.(instructionSet)
-      instructionSet.add(this)
+      renderPipes.live2d!.addRenderable(this, instructionSet)
     }
 
     const collectChildren = () => {


### PR DESCRIPTION
Expose Live2DPlugin for explicit PixiJS v8 render pipe registration via extensions.add(Live2DPlugin).

Keep the existing lazy render pipe registration path for backward compatibility, but mark it deprecated and emit a runtime warning.

Update README usage examples across all languages to prefer explicit registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * Live2D 渲染插件现已正式导出，需通过 `extensions.add(Live2DPlugin)` 显式注册

* **文档**
  * 更新了所有 README 文档，明确说明新的插件注册步骤和更新的初始化代码示例

* **弃用**
  * 旧的隐式注册方式已弃用，使用时会显示一次性警告提示用户采用新的集成方式

<!-- end of auto-generated comment: release notes by coderabbit.ai -->