### PR TITLE
fix(cubism-modern): align model layout implementation with official SDK

### DIFF
--- a/src/cubism-common/InternalModel.ts
+++ b/src/cubism-common/InternalModel.ts
@@ -2,26 +2,13 @@ import { FocusController } from '@/cubism-common/FocusController'
 import type { ModelSettings } from '@/cubism-common/ModelSettings'
 import type { MotionManager, MotionManagerOptions } from '@/cubism-common/MotionManager'
 import type { ParallelMotionManager } from '@/cubism-common/ParallelMotionManager'
-import { LOGICAL_HEIGHT, LOGICAL_WIDTH } from '@/cubism-common/constants'
+import type { CommonLayout } from '@/cubism-common/layout'
+import { setupLayoutMatrix } from '@/cubism-common/layout'
 import { EventEmitter, Matrix } from 'pixi.js'
 import type { Mutable } from '@/types/helpers'
 import type { CubismMotion } from '@cubism/motion/cubismmotion'
 
-/**
- * Common layout definition shared between all Cubism versions.
- */
-export interface CommonLayout {
-  centerX?: number
-  centerY?: number
-  x?: number
-  y?: number
-  width?: number
-  height?: number
-  top?: number
-  bottom?: number
-  left?: number
-  right?: number
-}
+export type { CommonLayout } from '@/cubism-common/layout'
 
 /**
  * Common hit area definition shared between all Cubism versions.
@@ -206,35 +193,15 @@ export abstract class InternalModel extends EventEmitter {
     self.originalWidth = size[0]
     self.originalHeight = size[1]
 
-    const layout = Object.assign(
-      {
-        width: LOGICAL_WIDTH,
-        height: LOGICAL_HEIGHT
-      },
+    const bounds = setupLayoutMatrix(
+      this.localTransform,
+      this.originalWidth,
+      this.originalHeight,
       this.getLayout()
     )
 
-    this.localTransform.scale(layout.width / LOGICAL_WIDTH, layout.height / LOGICAL_HEIGHT)
-
-    self.width = this.originalWidth * this.localTransform.a
-    self.height = this.originalHeight * this.localTransform.d
-
-    // this calculation differs from Live2D SDK...
-    const offsetX =
-      (layout.x !== undefined && layout.x - layout.width / 2) ||
-      (layout.centerX !== undefined && layout.centerX) ||
-      (layout.left !== undefined && layout.left - layout.width / 2) ||
-      (layout.right !== undefined && layout.right + layout.width / 2) ||
-      0
-
-    const offsetY =
-      (layout.y !== undefined && layout.y - layout.height / 2) ||
-      (layout.centerY !== undefined && layout.centerY) ||
-      (layout.top !== undefined && layout.top - layout.height / 2) ||
-      (layout.bottom !== undefined && layout.bottom + layout.height / 2) ||
-      0
-
-    this.localTransform.translate(this.width * offsetX, -this.height * offsetY)
+    self.width = bounds.width
+    self.height = bounds.height
   }
 
   /**

--- a/src/cubism-common/layout.ts
+++ b/src/cubism-common/layout.ts
@@ -1,0 +1,200 @@
+import type { Matrix } from 'pixi.js'
+import { LOGICAL_HEIGHT, LOGICAL_WIDTH } from '@/cubism-common/constants'
+
+export interface CommonLayout {
+  centerX?: number
+  centerY?: number
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  top?: number
+  bottom?: number
+  left?: number
+  right?: number
+}
+
+export interface LayoutBounds {
+  width: number
+  height: number
+}
+
+type LayoutKey = keyof CommonLayout
+type LayoutEntry = [LayoutKey, number]
+
+function setScale(matrix: Matrix, scale: number): void {
+  matrix.a = scale
+  matrix.b = 0
+  matrix.c = 0
+  matrix.d = scale
+}
+
+function getLayoutEntries(rawLayout: CommonLayout): LayoutEntry[] {
+  const entries: LayoutEntry[] = []
+
+  for (const [key, value] of Object.entries(rawLayout)) {
+    if (typeof value !== 'number') {
+      continue
+    }
+
+    entries.push([key as LayoutKey, value])
+  }
+
+  return entries
+}
+
+/**
+ * Applies the historical common layout transform used by this project.
+ */
+export function setupLayoutMatrix(
+  matrix: Matrix,
+  originalWidth: number,
+  originalHeight: number,
+  rawLayout: CommonLayout
+): LayoutBounds {
+  const layout = {
+    width: LOGICAL_WIDTH,
+    height: LOGICAL_HEIGHT,
+    ...rawLayout
+  }
+  const layoutWidth = layout.width ?? LOGICAL_WIDTH
+  const layoutHeight = layout.height ?? LOGICAL_HEIGHT
+
+  matrix.identity()
+  matrix.scale(layoutWidth / LOGICAL_WIDTH, layoutHeight / LOGICAL_HEIGHT)
+
+  const width = originalWidth * matrix.a
+  const height = originalHeight * matrix.d
+
+  const offsetX =
+    (layout.x !== undefined && layout.x - layoutWidth / 2) ||
+    (layout.centerX !== undefined && layout.centerX) ||
+    (layout.left !== undefined && layout.left - layoutWidth / 2) ||
+    (layout.right !== undefined && layout.right + layoutWidth / 2) ||
+    0
+
+  const offsetY =
+    (layout.y !== undefined && layout.y - layoutHeight / 2) ||
+    (layout.centerY !== undefined && layout.centerY) ||
+    (layout.top !== undefined && layout.top - layoutHeight / 2) ||
+    (layout.bottom !== undefined && layout.bottom + layoutHeight / 2) ||
+    0
+
+  matrix.translate(width * offsetX, -height * offsetY)
+
+  return {
+    width,
+    height
+  }
+}
+
+interface CubismLayoutState {
+  scale: number
+  x: number
+  y: number
+}
+
+function getCubismLayoutWidth(state: CubismLayoutState, aspect: number): number {
+  return LOGICAL_HEIGHT * aspect * state.scale
+}
+
+function getCubismLayoutHeight(state: CubismLayoutState): number {
+  return LOGICAL_HEIGHT * state.scale
+}
+
+function setCubismWidth(state: CubismLayoutState, aspect: number, width: number): void {
+  state.scale = width / (LOGICAL_HEIGHT * aspect)
+}
+
+function setCubismHeight(state: CubismLayoutState, height: number): void {
+  state.scale = height / LOGICAL_HEIGHT
+}
+
+function setCubismX(state: CubismLayoutState, x: number): void {
+  state.x = x
+}
+
+function setCubismY(state: CubismLayoutState, y: number): void {
+  state.y = y
+}
+
+function centerCubismX(state: CubismLayoutState, aspect: number, x: number): void {
+  setCubismX(state, x - getCubismLayoutWidth(state, aspect) / 2)
+}
+
+function centerCubismY(state: CubismLayoutState, y: number): void {
+  setCubismY(state, y - getCubismLayoutHeight(state) / 2)
+}
+
+function rightCubism(state: CubismLayoutState, aspect: number, x: number): void {
+  setCubismX(state, x - getCubismLayoutWidth(state, aspect))
+}
+
+function bottomCubism(state: CubismLayoutState, y: number): void {
+  setCubismY(state, y - getCubismLayoutHeight(state))
+}
+
+/**
+ * Applies model3.json layout with the same two-pass semantics as
+ * CubismModelMatrix.setupFromLayout(), then converts the SDK logical matrix back
+ * to this renderer's top-left pixel local coordinates.
+ */
+export function setupCubismLayoutMatrix(
+  matrix: Matrix,
+  originalWidth: number,
+  originalHeight: number,
+  rawLayout: CommonLayout
+): LayoutBounds {
+  if (originalWidth <= 0 || originalHeight <= 0) {
+    matrix.identity()
+    return { width: 0, height: 0 }
+  }
+
+  const entries = getLayoutEntries(rawLayout)
+  const aspect = originalWidth / originalHeight
+  const state: CubismLayoutState = { scale: 1, x: 0, y: 0 }
+
+  for (const [key, value] of entries) {
+    if (key === 'width') {
+      setCubismWidth(state, aspect, value)
+    } else if (key === 'height') {
+      setCubismHeight(state, value)
+    }
+  }
+
+  for (const [key, value] of entries) {
+    if (key === 'x') {
+      setCubismX(state, value)
+    } else if (key === 'y') {
+      setCubismY(state, value)
+    } else if (key === 'centerX') {
+      centerCubismX(state, aspect, value)
+    } else if (key === 'centerY') {
+      centerCubismY(state, value)
+    } else if (key === 'top') {
+      setCubismY(state, value)
+    } else if (key === 'bottom') {
+      bottomCubism(state, value)
+    } else if (key === 'left') {
+      setCubismX(state, value)
+    } else if (key === 'right') {
+      rightCubism(state, aspect, value)
+    }
+  }
+
+  const pixelsPerLogicalUnit = originalHeight / LOGICAL_HEIGHT
+  const defaultLogicalHalfWidth = (LOGICAL_HEIGHT * aspect) / 2
+  const defaultLogicalHalfHeight = LOGICAL_HEIGHT / 2
+
+  matrix.identity()
+  setScale(matrix, state.scale)
+  matrix.tx =
+    pixelsPerLogicalUnit * (state.x + defaultLogicalHalfWidth) - (originalWidth * state.scale) / 2
+  matrix.ty =
+    pixelsPerLogicalUnit * (defaultLogicalHalfHeight - state.y) - (originalHeight * state.scale) / 2
+
+  return {
+    width: originalWidth * state.scale,
+    height: originalHeight * state.scale
+  }
+}

--- a/src/cubism/CubismInternalModel.ts
+++ b/src/cubism/CubismInternalModel.ts
@@ -1,6 +1,7 @@
 import type { InternalModelOptions } from '@/cubism-common'
 import type { CommonHitArea, CommonLayout } from '@/cubism-common/InternalModel'
 import { InternalModel, normalizeHitAreaDefs } from '@/cubism-common/InternalModel'
+import { setupCubismLayoutMatrix } from '@/cubism-common/layout'
 import type { CubismModelSettings } from '@/cubism/CubismModelSettings'
 import { CubismMotionManager } from '@/cubism/CubismMotionManager'
 import { CubismParallelMotionManager } from '@/cubism/CubismParallelMotionManager'
@@ -37,6 +38,31 @@ type MaskProfile = {
   maxMasksPerDrawable: number
   maskedVertexCount: number
   totalVertexCount: number
+}
+
+const layoutKeyMap: Record<string, keyof CommonLayout> = {
+  CenterX: 'centerX',
+  centerX: 'centerX',
+  center_x: 'centerX',
+  CenterY: 'centerY',
+  centerY: 'centerY',
+  center_y: 'centerY',
+  X: 'x',
+  x: 'x',
+  Y: 'y',
+  y: 'y',
+  Width: 'width',
+  width: 'width',
+  Height: 'height',
+  height: 'height',
+  Top: 'top',
+  top: 'top',
+  Bottom: 'bottom',
+  bottom: 'bottom',
+  Left: 'left',
+  left: 'left',
+  Right: 'right',
+  right: 'right'
 }
 
 function getRequiredMaskRenderTextureCount(model: CubismModel): number {
@@ -287,12 +313,12 @@ export class CubismInternalModel extends InternalModel {
     const settingsLayout = this.settings.layout
 
     if (settingsLayout) {
-      // un-capitalize each key to satisfy the common layout format
-      // e.g. CenterX -> centerX
       for (const [key, value] of Object.entries(settingsLayout)) {
-        const commonKey = key.charAt(0).toLowerCase() + key.slice(1)
+        const commonKey = layoutKeyMap[key]
 
-        layout[commonKey as keyof CommonLayout] = value
+        if (commonKey && typeof value === 'number') {
+          layout[commonKey] = value
+        }
       }
     }
 
@@ -300,11 +326,26 @@ export class CubismInternalModel extends InternalModel {
   }
 
   protected setupLayout() {
-    super.setupLayout()
-    ;(this as Mutable<this>).pixelsPerUnit = this.coreModel.getModel().canvasinfo.PixelsPerUnit
+    const self = this as Mutable<this>
+    const size = this.getSize()
+
+    self.originalWidth = size[0]
+    self.originalHeight = size[1]
+    self.pixelsPerUnit = this.coreModel.getModel().canvasinfo.PixelsPerUnit
+
+    const bounds = setupCubismLayoutMatrix(
+      this.localTransform,
+      this.originalWidth,
+      this.originalHeight,
+      this.getLayout()
+    )
+
+    self.width = bounds.width
+    self.height = bounds.height
 
     // move the origin from top left to center
     this.modelTransform
+      .identity()
       .scale(this.pixelsPerUnit, this.pixelsPerUnit)
       .translate(this.originalWidth / 2, this.originalHeight / 2)
   }


### PR DESCRIPTION
Resolves: #22 

CubismInternalModel 现在使用与官方 Cubism SDK 等价的 model3 layout 处理方式：width / height 会产生统一缩放，位置参数按 SDK 的两阶段布局语义应用，再转换回当前渲染器使用的 top-left 像素坐标。