### PR TITLE
feat(motion): add loop override to parallel motions

### DIFF
--- a/README-JA.md
+++ b/README-JA.md
@@ -47,12 +47,13 @@ const model = await Live2DModel.from('model.json', {
 
 - **並列再生**：複数のモーショングループを同時に駆動（上半身・下半身の独立アニメーションなど）
 - **最終フレーム固定**：モーションを最終フレームで停止させる（立ち絵の切り替え、ポーズ固定など）
+- **ループ上書き**：各並列モーション項目に `loop` を指定して、Cubism 3/4/5 モーション JSON のループ設定を上書きできます
 
 ```ts
 // 並列再生
 model.parallelMotion([
   { group: 'upper_body', index: 0 },
-  { group: 'lower_body', index: 1 }
+  { group: 'lower_body', index: 1, loop: true }
 ])
 
 // 最終フレーム固定
@@ -184,7 +185,7 @@ model.motion('group', index)
 ```ts
 model.parallelMotion([
   { group: group1, index: index1 },
-  { group: group2, index: index2 }
+  { group: group2, index: index2, loop: true }
 ])
 ```
 

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -47,12 +47,13 @@ const model = await Live2DModel.from('model.json', {
 
 - **并行播放**：同时驱动多个动作组，适用于上下半身独立动画等场景
 - **末帧冻结**：将动作定格在最后一帧，适用于立绘切换、姿态固定
+- **循环覆盖**：可在每个并行动作条目中设置 `loop`，覆盖 Cubism 3/4/5 动作 JSON 中的循环配置
 
 ```ts
 // 并行播放
 model.parallelMotion([
   { group: 'upper_body', index: 0 },
-  { group: 'lower_body', index: 1 }
+  { group: 'lower_body', index: 1, loop: true }
 ])
 
 // 末帧冻结
@@ -185,7 +186,7 @@ model.motion('group', index)
 ```ts
 model.parallelMotion([
   { group: group1, index: index1 },
-  { group: group2, index: index2 }
+  { group: group2, index: index2, loop: true }
 ])
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ Complex models (many masked drawables, high vertex density, etc.) can produce vi
 
 - **Parallel playback**: drive multiple motion groups simultaneously, useful for independent upper/lower body animations
 - **Last-frame freeze**: hold a motion on its final frame, useful for pose switching or static illustrations
+- **Loop override**: set `loop` per parallel motion item to override Cubism 3/4/5 motion JSON loop metadata
 
 ```ts
 // Parallel playback
 model.parallelMotion([
   { group: 'upper_body', index: 0 },
-  { group: 'lower_body', index: 1 }
+  { group: 'lower_body', index: 1, loop: true }
 ])
 
 // Last-frame freeze
@@ -184,7 +185,7 @@ model.motion('group', index)
 ```ts
 model.parallelMotion([
   { group: group1, index: index1 },
-  { group: group2, index: index2 }
+  { group: group2, index: index2, loop: true }
 ])
 ```
 

--- a/src/Live2DModel.ts
+++ b/src/Live2DModel.ts
@@ -649,6 +649,8 @@ export class Live2DModel<IM extends InternalModel = InternalModel> extends Conta
    *  group: The motion group,
    *  index: Index in the motion group,
    *  priority: The priority to be applied. (0: No priority, 1: IDLE, 2:NORMAL, 3:FORCE) (default: 2)
+   *  ignoreParamIds: The ids to be ignored,
+   *  loop: Whether the motion should loop.
    * @return Promise that resolves with a list, indicates the motion is successfully started, with false otherwise.
    */
   async parallelMotion(
@@ -656,11 +658,16 @@ export class Live2DModel<IM extends InternalModel = InternalModel> extends Conta
       group: string
       index: number
       priority?: MotionPriority
+      ignoreParamIds?: string[]
+      loop?: boolean
     }[]
   ): Promise<boolean[]> {
     this.internalModel.extendParallelMotionManager(motionList.length)
     const result = motionList.map((m, idx) =>
-      this.internalModel.parallelMotionManager[idx]!.startMotion(m.group, m.index, m.priority)
+      this.internalModel.parallelMotionManager[idx]!.startMotion(m.group, m.index, m.priority, {
+        ignoreParamIds: m.ignoreParamIds,
+        loop: m.loop
+      })
     )
     const flags: boolean[] = []
     for (const r of result) {

--- a/src/cubism-common/ParallelMotionManager.ts
+++ b/src/cubism-common/ParallelMotionManager.ts
@@ -7,6 +7,16 @@ import { logger } from '@/utils'
 import { EventEmitter } from 'pixi.js'
 import type { InternalModel } from '@/cubism-common/InternalModel'
 
+export interface ParallelMotionStartOptions {
+  ignoreParamIds?: string[]
+  /**
+   * Whether the motion should loop. Overrides Cubism 3/4/5 motion JSON loop metadata when specified.
+   */
+  loop?: boolean
+}
+
+export type ParallelMotionStartRandomOptions = Omit<ParallelMotionStartOptions, 'ignoreParamIds'>
+
 /**
  * Handles the motion playback.
  * @emits {@link MotionManagerEvents}
@@ -59,14 +69,19 @@ export abstract class ParallelMotionManager<
    * @param index - Index in the motion group.
    * @param priority - The priority to be applied. default: 2 (NORMAL)
    * @param ignoreParamIds - The ids to be ignored.
+   * @param loop - Whether the motion should loop. Overrides Cubism 3/4/5 motion JSON loop metadata when specified.
    * @return Promise that resolves with true if the motion is successfully started, with false otherwise.
    */
   async startMotion(
     group: string,
     index: number,
     priority: MotionPriority = MotionPriority.NORMAL,
-    ignoreParamIds: string[] = []
+    options: ParallelMotionStartOptions | string[] = {}
   ): Promise<boolean> {
+    const { ignoreParamIds = [], loop } = Array.isArray(options)
+      ? { ignoreParamIds: options, loop: undefined }
+      : options
+
     if (!this.state.reserve(group, index, priority)) {
       return false
     }
@@ -87,7 +102,7 @@ export abstract class ParallelMotionManager<
 
     this.playing = true
 
-    this._startMotion(motion! as Motion, undefined, ignoreParamIds)
+    this._startMotion(motion! as Motion, undefined, ignoreParamIds, loop)
 
     return true
   }
@@ -96,9 +111,14 @@ export abstract class ParallelMotionManager<
    * Starts a random Motion as given priority.
    * @param group - The motion group.
    * @param priority - The priority to be applied. (default: 1 `IDLE`)
+   * @param loop - Whether the motion should loop. Overrides Cubism 3/4/5 motion JSON loop metadata when specified.
    * @return Promise that resolves with true if the motion is successfully started, with false otherwise.
    */
-  async startRandomMotion(group: string, priority?: MotionPriority): Promise<boolean> {
+  async startRandomMotion(
+    group: string,
+    priority?: MotionPriority,
+    { loop = undefined }: ParallelMotionStartRandomOptions = {}
+  ): Promise<boolean> {
     const groupDefs = this.manager.definitions[group]
 
     if (groupDefs?.length) {
@@ -114,7 +134,7 @@ export abstract class ParallelMotionManager<
       if (availableIndices.length) {
         const index = availableIndices[Math.floor(Math.random() * availableIndices.length)]!
 
-        return this.startMotion(group, index, priority)
+        return this.startMotion(group, index, priority, { loop: loop })
       }
     }
 
@@ -176,7 +196,8 @@ export abstract class ParallelMotionManager<
   protected abstract _startMotion(
     motion: Motion,
     onFinish?: (motion: Motion) => void,
-    ignoreParamIds?: string[]
+    ignoreParamIds?: string[],
+    loop?: boolean
   ): number
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 现在可在并行动作中为单个动作项单独设置 `loop`，覆盖动作 JSON 的循环配置。
  * 并行动作播放支持更多可选设置，包含忽略参数与循环控制。

* **文档**
  * 更新中、日、英 README 示例，补充“循环覆盖”说明，并同步展示新的用法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->