### PR TITLE
fix(renderer): handle culling in filtered Cubism rendering

### DIFF
--- a/src/cubism/CubismInternalModel.ts
+++ b/src/cubism/CubismInternalModel.ts
@@ -498,8 +498,19 @@ export class CubismInternalModel extends InternalModel {
 
     this.renderer.setMvpMatrix(tempMatrix)
     const framebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING) as WebGLFramebuffer
+    const previousCullFaceMode = gl.getParameter(gl.CULL_FACE_MODE) as GLenum
+    const determinant = array[0] * array[5] - array[1] * array[4]
+
+    // Cubism always treats CCW triangles as front-facing. Keep the visible face consistent
+    // when Pixi flips the projection for render textures, filters, or mirrored transforms.
+    gl.cullFace(determinant < 0 ? gl.FRONT : gl.BACK)
     this.renderer.setRenderState(framebuffer, this.viewport)
-    this.renderer.drawModel()
+
+    try {
+      this.renderer.drawModel()
+    } finally {
+      gl.cullFace(previousCullFaceMode)
+    }
   }
 
   extendParallelMotionManager(managerCount: number) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复在渲染纹理、应用滤镜或进行镜像变换时，模型可见面方向错误的问题。
  * 改善模型绘制过程中的图形渲染状态管理，确保异常情况下也能恢复正常渲染。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->