### PR TITLE
fix(cubism): delete model through moc to satisfy model count

### DIFF
--- a/src/cubism/CubismInternalModel.ts
+++ b/src/cubism/CubismInternalModel.ts
@@ -523,7 +523,6 @@ export class CubismInternalModel extends InternalModel {
     super.destroy()
 
     this.renderer.release()
-    this.coreModel.release()
     ;(this as Partial<this>).renderer = undefined
     ;(this as Partial<this>).coreModel = undefined
   }

--- a/src/cubism/factory.ts
+++ b/src/cubism/factory.ts
@@ -101,5 +101,8 @@ Live2DFactory.registerRuntime({
 })
 
 function releaseMoc(this: CubismInternalModel) {
-  ;(this as CubismInternalModel & ModelWithMoc).__moc?.release()
+  const moc = (this as CubismInternalModel & ModelWithMoc).__moc
+  // deleteModel decrements the model count that release() asserts is zero
+  moc?.deleteModel(this.coreModel)
+  moc?.release()
 }


### PR DESCRIPTION
## Problem

`CubismMoc._modelCount` is incremented by `createModel()` and decremented only by
`deleteModel()`. Teardown never called `deleteModel()`: `releaseMoc()` called
`moc.release()` directly, and `CubismInternalModel.destroy()` released the core model
separately.

Since `release()` asserts `_modelCount == 0`, every model destroy trips
`CSM_ASSERT` at `cubismmoc.ts:108`.

## Reproduce

Load any Cubism 3/4/5 model, then destroy it:

```ts
const model = await Live2DModel.from('...model3.json')
model.destroy()
```

`Assertion failed: console.assert` appears in the console, with `releaseMoc` and
`cubismmoc.ts:108` in the stack.

## Fix

Call `deleteModel()` before releasing.
This matches `CubismUserModel.release()` in the Framework (`cubismusermodel.ts:463`).

The separate `coreModel.release()` in `destroy()` was removed because `deleteModel()` does it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化模型销毁与资源释放流程，避免模型清理过程中出现状态不一致。
  - 修复释放模型资源时的处理顺序问题，提升资源回收的稳定性。
  - 改善模型生命周期管理，降低销毁或释放操作失败的可能性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->